### PR TITLE
User can highlight breakpoint and program counter signs and lines

### DIFF
--- a/doc/lldb.txt
+++ b/doc/lldb.txt
@@ -130,6 +130,43 @@ CUSTOMIZING                                             *lldb-customizing*
 
 ==============================================================================
 
+HIGHLIGHTING                                            *lldb-highlighting*
+
+To customize the highlighting of signs, use the following highlight groups:
+
+    *LLBreakpointSign*
+                      For breakpoint signs, links to |Type| by default.
+
+    *LLSelectedPCSign*
+                      For the selected program counter sign, links to |Debug|
+                      by default.
+
+    *LLUnselectedPCSign*
+                      For the unselected program counter sign, links to to
+                      |NonText| by default.
+
+Example: >
+    highlight LLBreakpointSign ctermfg=cyan guifg=cyan
+
+To customize highlighting for the line where a sign resides, you can use the
+following highlight groups:
+
+    *LLBreakpointLine*
+                      For breakpoint lines, unhighlighted by default.
+
+    *LLSelectedPCLine*
+                      For the current line of the selected program counter,
+                      links to |DiffText| by default.
+
+    *LLUnselectedPCLine*
+                      For the current line of the unselected program counter,
+                      links to |DiffChange| by default.
+
+Example: >
+    highlight LLSelectedPCLine ctermbg=DarkGrey guibg=DarkGrey
+
+==============================================================================
+
 COMMANDS                                                *lldb-commands*
 
                                                         *:LL*

--- a/plugin/lldb.vim
+++ b/plugin/lldb.vim
@@ -21,11 +21,15 @@ endif
 let s:bp_symbol = get(g:, 'lldb#sign#bp_symbol', 'B>')
 let s:pc_symbol = get(g:, 'lldb#sign#pc_symbol', '->')
 
-highlight LLSelectedPCLine ctermbg=darkblue guibg=darkblue
-highlight LLUnselectedPCLine ctermbg=black guibg=black
+highlight default link LLBreakpointSign Type
+highlight default link LLUnselectedPCSign NonText
+highlight default link LLUnselectedPCLine DiffChange
+highlight default link LLSelectedPCSign Debug
+highlight default link LLSelectedPCLine DiffText
 
-execute 'sign define llsign_bpres text=' . s:bp_symbol
+execute 'sign define llsign_bpres text=' . s:bp_symbol .
+    \ ' texthl=LLBreakpointSign linehl=LLBreakpointLine'
 execute 'sign define llsign_pcsel text=' . s:pc_symbol .
-    \ ' texthl=LLSelectedPCLine linehl=LLSelectedPCLine'
+    \ ' texthl=LLSelectedPCSign linehl=LLSelectedPCLine'
 execute 'sign define llsign_pcunsel text=' . s:pc_symbol .
-    \ ' texthl=LLUnselectedPCLine linehl=LLUnselectedPCLine'
+    \ ' texthl=LLUnselectedPCSign linehl=LLUnselectedPCLine'


### PR DESCRIPTION
@critiqjo This resolves #12. Included are separate highlighting groups for the following:

* Breakpoint signs/lines
* Selected Program Counter signs/lines
* Unselected Program Counter signs/lines

Additionally, I've set the defaults to be more overridable values. If you prefer, we can retain the original black/blue scheme.