### PR TITLE
Readme: Path passed to Plug should use single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and communicates with the Neovim process using RPC calls.
 1. Using a plugin manager such as [vim-plug](https://github.com/junegunn/vim-plug):
 
    ```
-       Plug "critiqjo/lldb.nvim"
+       Plug 'critiqjo/lldb.nvim'
    ```
 
    Alternatively, clone this repo, and add the following line to your nvimrc:


### PR DESCRIPTION
From [vim-plug](junegunn/vim-plug)'s Example section on the README:

```vim
" Make sure you use single quotes
Plug 'junegunn/seoul256.vim'
```

I did test with the double quotes, as I copy-pasted the command fron lldb.nvim's README, and I did got an error on the command's line. Switching to single quotes solved it.