### PR TITLE
Implemented interactive buffers.

### DIFF
--- a/autoload/lldb/layout.vim
+++ b/autoload/lldb/layout.vim
@@ -8,6 +8,39 @@ function! s:logs_clear()
   endif
 endfun
 
+" Given the regex, extracts the match from the current line in the buffer.
+" If there's no match, the fallback_str is returned.
+function! s:matchstr_with_fallback(line, regex, fallback_str)
+  let matched = matchstr(a:line, a:regex)
+  if matched == ""
+    return a:fallback_str
+  else
+    return matched
+  endif
+endfun
+
+" Returns [thread_id, frame_id] corresponding to the line in the backtrace buffer.
+" If any entry of the pair has no result, empty string will be used.
+function! lldb#layout#backtrace_retrieve()
+  let frame_idx_pattern = '^\s*\*\= frame #\zs\d\+'
+  let thread_idx_pattern = '^\s*\*\= thread #\zs\d\+'
+  let frame_id = matchstr(getline('.'), frame_idx_pattern)
+  let line_offset = frame_id == '' ? -1 : +frame_id
+  let thread_id = matchstr(getline(line('.') - line_offset - 1), thread_idx_pattern)
+  if frame_id == '-1'
+    let frame_id = ''
+  endif
+  return [thread_id, frame_id]
+endfun
+
+" Returns breakpoint id correnponding to the line in the breakpoint buffer.
+" If the result is invalid, empty string will be returned.
+function! lldb#layout#breakpoint_retrieve()
+  let bp_idx_pattern = '^\s*\zs\d\+\.\=\d*'
+  let frame_id = matchstr(getline('.'), bp_idx_pattern)
+  return frame_id
+endfun
+
 function! lldb#layout#init_buffers()
   let s:buffers = [ 'backtrace', 'breakpoints', 'disassembly',
                   \ 'locals', 'logs', 'registers', 'threads' ]
@@ -34,6 +67,12 @@ function! lldb#layout#init_window(width, split, bnr)
     nnoremap <buffer> i :call lldb#remote#stdin_prompt()<CR>
     nnoremap <silent> <buffer> <nowait> d :call <SID>logs_clear()<CR>
     nnoremap <silent> <buffer> <nowait> q :drop #<CR>
+  elseif s:buffer_map['backtrace'] == a:bnr || s:buffer_map['threads'] == a:bnr
+    nnoremap <silent> <buffer> <CR>
+            \ :call lldb#remote#__notify("select_thread_and_frame", lldb#layout#backtrace_retrieve())<CR>
+  elseif s:buffer_map['breakpoints'] == a:bnr
+    nnoremap <silent> <buffer> <nowait> x
+            \ :call lldb#remote#__notify("breakdelete", lldb#layout#breakpoint_retrieve())<CR>
   endif
 endfun
 

--- a/autoload/lldb/layout.vim
+++ b/autoload/lldb/layout.vim
@@ -68,6 +68,12 @@ function! lldb#layout#init_window(width, split, bnr)
     nnoremap <silent> <buffer> <nowait> d :call <SID>logs_clear()<CR>
     nnoremap <silent> <buffer> <nowait> q :drop #<CR>
   elseif s:buffer_map['backtrace'] == a:bnr || s:buffer_map['threads'] == a:bnr
+    if s:buffer_map['backtrace'] == a:bnr
+      nnoremap <silent> <buffer> a :call lldb#remote#__notify("btswitch")<CR>
+      nnoremap <silent> <buffer> t :drop [lldb]threads<CR>
+    else
+      nnoremap <silent> <buffer> a :drop [lldb]backtrace<CR>
+    endif
     nnoremap <silent> <buffer> <CR>
             \ :call lldb#remote#__notify("select_thread_and_frame", lldb#layout#backtrace_retrieve())<CR>
   elseif s:buffer_map['breakpoints'] == a:bnr

--- a/autoload/lldb/layout.vim
+++ b/autoload/lldb/layout.vim
@@ -19,19 +19,22 @@ function! lldb#layout#init_buffers()
     call setbufvar(bnr, '&bt', 'nofile')
     call setbufvar(bnr, '&swf', 0)
     call setbufvar(bnr, '&ma', 0)
-    exe 'silent b ' . bnr
-    if bname == 'logs'
-      nnoremap <buffer> i :call lldb#remote#stdin_prompt()<CR>
-      nnoremap <silent> <buffer> <nowait> d :call <SID>logs_clear()<CR>
-      nnoremap <silent> <buffer> <nowait> q :drop #<CR>
-    endif
-    call setbufvar(bnr, '&nu', 0)
-    call setbufvar(bnr, '&rnu', 0)
     call setbufvar(bnr, '&bl', 0)
     let s:buffer_map[bname] = bnr
   endfor
-  exe 'b ' . u_bnr
+  exe 'silent b ' . u_bnr
   return s:buffer_map
+endfun
+
+function! lldb#layout#init_window(width, split, bnr)
+  exe 'belowright ' . a:width . a:split . '+b' . a:bnr
+  set nonu
+  set nornu
+  if s:buffer_map['logs'] == a:bnr
+    nnoremap <buffer> i :call lldb#remote#stdin_prompt()<CR>
+    nnoremap <silent> <buffer> <nowait> d :call <SID>logs_clear()<CR>
+    nnoremap <silent> <buffer> <nowait> q :drop #<CR>
+  endif
 endfun
 
 function! lldb#layout#setup(mode)
@@ -45,16 +48,16 @@ function! lldb#layout#setup(mode)
   let winw2 = winwidth(0)*2/5
   let winw3 = winwidth(0)*3/5
   let winh2 = winheight(0)*2/3
-  exe 'belowright ' . winw3 . 'vsp +b' . s:buffer_map['threads']
-  exe 'belowright ' . winh2 . 'sp +b' . s:buffer_map['disassembly']
-  exe 'belowright ' . winw3/2 . 'vsp +b' . s:buffer_map['registers']
+  call lldb#layout#init_window(winw3, 'vsp', s:buffer_map['threads'])
+  call lldb#layout#init_window(winh2, 'sp', s:buffer_map['disassembly'])
+  call lldb#layout#init_window(winw3/2, 'vsp', s:buffer_map['registers'])
   2wincmd h
   0tab sp
-  exe 'belowright ' . winw2 . 'vsp +b' . s:buffer_map['backtrace']
-  exe 'belowright ' . winh2 . 'sp +b' . s:buffer_map['breakpoints']
-  exe 'belowright ' . winh2/2 . 'sp +b' . s:buffer_map['locals']
+  call lldb#layout#init_window(winw2, 'vsp', s:buffer_map['backtrace'])
+  call lldb#layout#init_window(winh2, 'sp', s:buffer_map['breakpoints'])
+  call lldb#layout#init_window(winh2/2, 'sp', s:buffer_map['locals'])
   wincmd h
-  exe 'belowright ' . winh2/2 . 'sp +b' . s:buffer_map['logs']
+  call lldb#layout#init_window(winh2/2, 'sp', s:buffer_map['logs'])
   set cole=2 cocu=nc
   wincmd k
 endfun

--- a/autoload/lldb/remote.vim
+++ b/autoload/lldb/remote.vim
@@ -1,4 +1,4 @@
-function! s:llnotify(event, ...) abort
+function! lldb#remote#__notify(event, ...) abort
   if !exists('g:lldb#_channel_id')
     throw 'LLDB: channel id not defined!'
   endif
@@ -8,7 +8,7 @@ endfun
 
 function! lldb#remote#init(chan_id)
   let g:lldb#_channel_id = a:chan_id
-  au VimLeavePre * call <SID>llnotify('exit')
+  au VimLeavePre * call lldb#remote#__notify('exit')
   call lldb#remote#define_commands()
 endfun
 
@@ -42,7 +42,7 @@ function! lldb#remote#stdin_prompt(...)
   else
     let strin = input('line> ') . "\n"
   endif
-  call s:llnotify("stdin", strin)
+  call lldb#remote#__notify("stdin", strin)
 endfun
 
 function! lldb#remote#get_modes()
@@ -54,16 +54,16 @@ function! lldb#remote#get_modes()
 endfun
 
 function! lldb#remote#define_commands()
-  command!  LLrefresh   call <SID>llnotify("refresh")
+  command!  LLrefresh   call lldb#remote#__notify("refresh")
   command!      -nargs=1    -complete=customlist,lldb#session#complete
-          \ LLmode      call <SID>llnotify("mode", <f-args>)
+          \ LLmode      call lldb#remote#__notify("mode", <f-args>)
   command!      -nargs=*    -complete=customlist,<SID>llcomplete
-          \ LL          call <SID>llnotify("exec", <f-args>)
+          \ LL          call lldb#remote#__notify("exec", <f-args>)
   command!      -nargs=?    -complete=customlist,<SID>stdincompl
           \ LLstdin     call lldb#remote#stdin_prompt(<f-args>)
 
   nnoremap <silent> <Plug>LLBreakSwitch
-          \ :call <SID>llnotify("breakswitch", bufnr("%"), getcurpos()[1])<CR>
+          \ :call lldb#remote#__notify("breakswitch", bufnr("%"), getcurpos()[1])<CR>
   vnoremap <silent> <Plug>LLStdInSelected
-          \ :<C-U>call <SID>llnotify("stdin", lldb#util#get_selection())<CR>
+          \ :<C-U>call lldb#remote#__notify("stdin", lldb#util#get_selection())<CR>
 endfun

--- a/rplugin/python/lldb_nvim/__init__.py
+++ b/rplugin/python/lldb_nvim/__init__.py
@@ -77,6 +77,10 @@ class Middleman(object):
     if thread_and_frame_idx[1]:
       self.ctrl.safe_execute(['frame', 'select', thread_and_frame_idx[1]])
 
+  @neovim.rpc_export('btswitch')
+  def _btswitch(self):
+    self.ctrl.safe_call(self.ctrl.do_btswitch)
+
   @neovim.rpc_export('breakswitch')
   def _breakswitch(self, bufnr, line):
     self.ctrl.safe_call(self.ctrl.do_breakswitch, [bufnr, line])

--- a/rplugin/python/lldb_nvim/__init__.py
+++ b/rplugin/python/lldb_nvim/__init__.py
@@ -70,9 +70,20 @@ class Middleman(object):
       self.logger.warn(str(e))
       return []
 
+  @neovim.rpc_export('select_thread_and_frame')
+  def _select_thread_and_frame(self, thread_and_frame_idx):
+    if thread_and_frame_idx[0]:
+      self.ctrl.safe_execute(['thread', 'select', thread_and_frame_idx[0]])
+    if thread_and_frame_idx[1]:
+      self.ctrl.safe_execute(['frame', 'select', thread_and_frame_idx[1]])
+
   @neovim.rpc_export('breakswitch')
   def _breakswitch(self, bufnr, line):
     self.ctrl.safe_call(self.ctrl.do_breakswitch, [bufnr, line])
+
+  @neovim.rpc_export('breakdelete')
+  def _breakdelete(self, bp_id):
+    self.ctrl.safe_call(self.ctrl.do_breakdelete, [bp_id])
 
   @neovim.rpc_export('refresh')
   def _refresh(self):

--- a/rplugin/python/lldb_nvim/__init__.py
+++ b/rplugin/python/lldb_nvim/__init__.py
@@ -33,10 +33,10 @@ class Middleman(object):
 
   @neovim.rpc_export('exec')
   def _exec(self, *args):
-    if args[0] == 'disassemble':
-      self.ctrl.safe_call(self.ctrl.do_disassemble, [' '.join(args)])
-      if self.ctrl._target is not None:
-        self.ctrl.vimx.command('drop [lldb]disassembly')
+    if args[0] in ['di', 'dis', 'disassemble']:
+      self.ctrl.safe_call(self.ctrl.change_buffer_cmd, ['disassembly', ' '.join(args)])
+    elif args[0] in ['bt', '_regexp-bt']:
+      self.ctrl.safe_call(self.ctrl.change_buffer_cmd, ['backtrace', ' '.join(args)])
     else:
       self.ctrl.safe_execute(args)
 

--- a/rplugin/python/lldb_nvim/controller.py
+++ b/rplugin/python/lldb_nvim/controller.py
@@ -190,10 +190,12 @@ class Controller(Thread):
 
     return changes
 
-  def do_disassemble(self, cmd):
-    """ Change the `disassembly` buffer command and update it. """
-    self.buffers._content_map['disassembly'] = cmd
-    self.update_buffers(buf='disassembly')
+  def change_buffer_cmd(self, buf, cmd):
+    """ Change a buffer command and update it. """
+    self.buffers._content_map[buf] = cmd
+    self.update_buffers(buf=buf)
+    if self._target is not None:
+      self.vimx.command('drop [lldb]%s' % buf)
 
   def bp_set_line(self, spath, line):
     from os.path import abspath

--- a/rplugin/python/lldb_nvim/controller.py
+++ b/rplugin/python/lldb_nvim/controller.py
@@ -197,6 +197,15 @@ class Controller(Thread):
     if self._target is not None:
       self.vimx.command('drop [lldb]%s' % buf)
 
+  def do_btswitch(self):
+    """ Switch backtrace command to show all threads. """
+    cmd = self.buffers._content_map['backtrace']
+    if cmd != 'bt all':
+      cmd = 'bt all'
+    else:
+      cmd = 'bt'
+    self.change_buffer_cmd('backtrace', cmd)
+
   def bp_set_line(self, spath, line):
     from os.path import abspath
     fpath = abspath(spath).encode('ascii', 'ignore')

--- a/rplugin/python/lldb_nvim/controller.py
+++ b/rplugin/python/lldb_nvim/controller.py
@@ -213,6 +213,11 @@ class Controller(Thread):
     else:
       self.bp_set_line(self.vimx.get_buffer_name(bufnr), line)
 
+  def do_breakdelete(self, bp_id):
+    """ Delete a breakpoint by id """
+    if bp_id:
+      self.exec_command("breakpoint delete {}".format(bp_id))
+
   def put_stdin(self, instr):
     """ Call PutSTDIN() of process with instr. """
     if self._process is not None:


### PR DESCRIPTION
Implements the feature in #9, except for the watchpoints.

In the end, I skip the syntax idea all together, and perform the regex myself. The ideal way is to extract substring using Vim's syntax mechanism, but the most I can do is looking up what syntax group a specific location belongs to. If I want to do anything more, I might need to scan the whole line, which makes things more complicated.

Also, I promoted "llnotify" to global namespace because it's now used in layout.vim as well. I understand this is probably something to hide from the user. Maybe we need another commit to re-organize the functions.

