### PR TITLE
`lldb_utils.resolve_line_entry()`: `target.source-map`, Fixes #37

### DIFF
--- a/rplugin/python/lldb_nvim/controller.py
+++ b/rplugin/python/lldb_nvim/controller.py
@@ -43,7 +43,7 @@ class Controller(Thread):
 
     self.vimx = vimx
     self.busy_stack = 0 # when > 0, buffers are not updated
-    self.buffers = VimBuffers(vimx)
+    self.buffers = VimBuffers(self, vimx)
     self.session = Session(self, vimx)
 
     super(Controller, self).__init__() # start the thread
@@ -132,11 +132,10 @@ class Controller(Thread):
     """
     if self.is_busy():
       return
-    commander = self.get_command_result
     if buf is None:
-      self.buffers.update(self._target, commander)
+      self.buffers.update(self._target)
     else:
-      self.buffers.update_buffer(buf, self._target, commander)
+      self.buffers.update_buffer(buf, self._target)
 
   def get_state_changes(self):
     """ Get a value denoting how target, process, and/or breakpoint have changed.

--- a/rplugin/python/lldb_nvim/lldb_utils.py
+++ b/rplugin/python/lldb_nvim/lldb_utils.py
@@ -1,7 +1,39 @@
-def resolve_line_entry(le):
-  return (le.file.fullpath, le.line)
+import os.path
 
-def get_pc_source_loc(thread):
+def settings_target_source_map(commander):
+  (success, output) = commander('settings show target.source-map')
+  if not success:
+    return None
+
+  path_map = {}
+  for line in output.splitlines()[1:]:
+    try:
+      path_src_start = line.index('"') + 1
+      path_src, path_dest = line[path_src_start:-1].split('" -> "')
+    except ValueError:
+      continue
+    if not os.path.isabs(path_src) or not os.path.isabs(path_dest):
+      continue
+    path_map[os.path.abspath(path_src)] = os.path.abspath(path_dest)
+
+  return path_map
+
+def resolve_line_entry(le, source_map=None):
+  fullpath = le.file.fullpath
+  if not source_map:
+    return (fullpath, le.line)
+
+  fullpath_new = None
+  for path_src, path_dest in sorted(source_map.items(), key=lambda item: len(item[0])):
+    if fullpath.startswith(path_src + os.path.sep):
+      fullpath_new = path_dest + fullpath[len(path_src):]
+
+  if fullpath_new is not None:
+    fullpath = fullpath_new
+
+  return (fullpath, le.line)
+
+def get_pc_source_loc(thread, commander):
   """ Returns a tuple (thread_index, file, line) that represents where
       the PC sign should be placed for a thread.
   """
@@ -13,16 +45,16 @@ def get_pc_source_loc(thread):
     le = thread.GetFrameAtIndex(frame_num).line_entry
 
   if le.IsValid():
-    return (thread.GetIndexID(),) + resolve_line_entry(le)
+    return (thread.GetIndexID(),) + resolve_line_entry(le, settings_target_source_map(commander))
   return None
 
-def get_bploc_tuples(bp):
+def get_bploc_tuples(bp, source_map=None):
   """ Returns a list of tuples (file, line) where a breakpoint was resolved. """
   if not bp.IsValid():
     return []
   locs = []
   for bploc in bp:
-    le_tupl = resolve_line_entry(bploc.GetAddress().line_entry)
+    le_tupl = resolve_line_entry(bploc.GetAddress().line_entry, source_map)
     if le_tupl[0] and le_tupl[1] > 0: # le_tupl[0] might be None
       locs.append(le_tupl)
   return locs

--- a/rplugin/python/lldb_nvim/session.py
+++ b/rplugin/python/lldb_nvim/session.py
@@ -28,9 +28,10 @@ class Session:
     """ Sets the value of bp.id key by trying to resolve bp to a single location;
         if not possible, sets the value to fallback
     """
-    from .lldb_utils import get_bploc_tuples
+    from .lldb_utils import get_bploc_tuples, settings_target_source_map
     if bp.GetNumLocations() == 1:
-      self.bpid_map[bp.id] = get_bploc_tuples(bp)[0]
+      self.bpid_map[bp.id] = get_bploc_tuples(
+        bp, settings_target_source_map(self.ctrl.get_command_result))[0]
     else:
       self.bpid_map[bp.id] = fallback
 


### PR DESCRIPTION
SBFrame.GetLineEntry() is cached after first call, meaning that you
have to set `target.source-map` before loading a debugger target.

This commit fixes that by taking `target.source-map` into account when resolving
`SBLineEntry.file.fullpath`.

The current implementation is a bit hacky, but the LLDB API does not
currently expose a proper way of querying for `target.source-map`.